### PR TITLE
Add WebSocket log viewer to web UI

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -28,3 +28,4 @@ lib_ignore =
 	ESPAsyncTCP
 	RPAsyncTCP
 lib_ldf_mode = deep
+build_src_flags = -include log_buffer.h

--- a/src/log_buffer.cpp
+++ b/src/log_buffer.cpp
@@ -1,0 +1,118 @@
+#include <Arduino.h>
+// Define HWSerial BEFORE including log_buffer.h so the reference
+// binds to the real Serial object (before the macro replaces it).
+HardwareSerial& HWSerial = Serial;
+
+#include "log_buffer.h"
+
+LogBuffer Logger;
+
+LogBuffer::LogBuffer() {
+    mutex = xSemaphoreCreateMutex();
+}
+
+void LogBuffer::begin(unsigned long baud) {
+    HWSerial.begin(baud);
+}
+
+void LogBuffer::setWebSocket(AsyncWebSocket* websocket) {
+    ws = websocket;
+}
+
+void LogBuffer::addToBuffer(uint8_t c) {
+    // CALLER MUST HOLD MUTEX
+    buffer[head] = c;
+    head = (head + 1) % BUFFER_SIZE;
+    if (head == tail) {
+        tail = (tail + 1) % BUFFER_SIZE;
+    }
+}
+
+void LogBuffer::addToBuffer(const uint8_t* data, size_t len) {
+    // CALLER MUST HOLD MUTEX
+    for (size_t i = 0; i < len; i++) {
+        addToBuffer(data[i]);
+    }
+}
+
+size_t LogBuffer::write(uint8_t c) {
+    HWSerial.write(c);
+
+    xSemaphoreTake(mutex, portMAX_DELAY);
+    addToBuffer(c);
+    if (pendingLen < PENDING_SIZE) {
+        pending[pendingLen++] = c;
+    }
+    xSemaphoreGive(mutex);
+
+    return 1;
+}
+
+size_t LogBuffer::write(const uint8_t* buf, size_t size) {
+    HWSerial.write(buf, size);
+
+    xSemaphoreTake(mutex, portMAX_DELAY);
+    addToBuffer(buf, size);
+    size_t canAdd = min(size, PENDING_SIZE - pendingLen);
+    if (canAdd > 0) {
+        memcpy(pending + pendingLen, buf, canAdd);
+        pendingLen += canAdd;
+    }
+    xSemaphoreGive(mutex);
+
+    return size;
+}
+
+void LogBuffer::sendHistory(uint32_t clientId) {
+    xSemaphoreTake(mutex, portMAX_DELAY);
+
+    if (head == tail) {
+        xSemaphoreGive(mutex);
+        return;
+    }
+
+    // Send in at most 2 chunks — zero allocations
+    if (head > tail) {
+        ws->text(clientId, &buffer[tail], head - tail);
+    } else {
+        ws->text(clientId, &buffer[tail], BUFFER_SIZE - tail);
+        if (head > 0) {
+            ws->text(clientId, &buffer[0], head);
+        }
+    }
+
+    xSemaphoreGive(mutex);
+}
+
+void LogBuffer::flush() {
+    if (!ws) return;
+
+    xSemaphoreTake(mutex, portMAX_DELAY);
+    if (pendingLen == 0) {
+        xSemaphoreGive(mutex);
+        return;
+    }
+
+    if (ws->count() == 0) {
+        // No clients — discard so pending doesn't grow stale
+        pendingLen = 0;
+        xSemaphoreGive(mutex);
+        return;
+    }
+
+    if (ws->availableForWriteAll()) {
+        ws->textAll(pending, pendingLen);
+        pendingLen = 0;
+    }
+    // If queue is still full, hold data and retry next tick
+
+    xSemaphoreGive(mutex);
+}
+
+void LogBuffer::ping() {
+    if (ws) ws->pingAll();
+}
+
+void LogBuffer::cleanup() {
+    if (ws) ws->cleanupClients();
+}

--- a/src/log_buffer.h
+++ b/src/log_buffer.h
@@ -1,0 +1,69 @@
+#ifndef LOG_BUFFER_H
+#define LOG_BUFFER_H
+
+#include <Arduino.h>
+#include <ESPAsyncWebServer.h>
+#include <freertos/semphr.h>
+
+// Save a reference to the REAL HardwareSerial BEFORE the macro
+extern HardwareSerial& HWSerial;
+
+class LogBuffer : public Print {
+private:
+    static const size_t BUFFER_SIZE = 4096;
+    char buffer[BUFFER_SIZE];
+    volatile size_t head = 0;
+    volatile size_t tail = 0;
+    SemaphoreHandle_t mutex;
+
+    AsyncWebSocket* ws = nullptr;
+
+    static const size_t PENDING_SIZE = 4096;
+    char pending[PENDING_SIZE];
+    size_t pendingLen = 0;
+
+    void addToBuffer(uint8_t c);
+    void addToBuffer(const uint8_t* data, size_t len);
+
+public:
+    LogBuffer();
+
+    // Wraps HardwareSerial initialization
+    void begin(unsigned long baud);
+
+    // Called after web server is set up
+    void setWebSocket(AsyncWebSocket* websocket);
+
+    // Print overrides — intercepts all print/println/printf
+    size_t write(uint8_t c) override;
+    size_t write(const uint8_t* buf, size_t size) override;
+
+    // Forward Serial input methods (used by calibration code)
+    int available() { return HWSerial.available(); }
+    int read() { return HWSerial.read(); }
+    int peek() { return HWSerial.peek(); }
+    String readStringUntil(char terminator) {
+        return HWSerial.readStringUntil(terminator);
+    }
+
+    // Send buffered history to a new WebSocket client
+    void sendHistory(uint32_t clientId);
+
+    // Send any pending WS data — call frequently (e.g. every 50ms)
+    void flush();
+
+    // Ping all connected WS clients (detects half-open connections)
+    void ping();
+
+    // Call periodically to clean up dead WS clients
+    void cleanup();
+};
+
+extern LogBuffer Logger;
+
+// Redirect Serial to Logger for all source files that include this header.
+// Library code won't include this header (build_src_flags only), so libraries
+// keep using the real Serial object.
+#define Serial Logger
+
+#endif // LOG_BUFFER_H

--- a/src/web/css/styles.css
+++ b/src/web/css/styles.css
@@ -37,7 +37,8 @@
     32. OTA Manual Upload
     33. Hardware Configuration
     34. Custom Scrollbars
-    35. Media Queries
+    35. Logs
+    36. Media Queries
    ============================================================================= */
 
 
@@ -1616,7 +1617,7 @@ input[type="submit"]:hover,
     display: none;
     justify-content: center;
     align-items: center;
-    z-index: 1001;
+    z-index: 10000;
 }
 
 .modal-overlay.visible {
@@ -1960,7 +1961,120 @@ input[type="submit"]:hover,
 }
 
 
-/* ==========  35. Media Queries  ============================================ */
+/* ==========  35. Logs  ===================================================== */
+
+.log-terminal {
+    background-color: #1c1c1c;
+    color: #ddd;
+    font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace;
+    font-size: 12px;
+    line-height: 1.45;
+    padding: 16px;
+    height: 300px;
+    overflow-y: auto;
+    border-radius: 3px;
+    white-space: pre-wrap;
+    overflow-wrap: break-word;
+    margin-top: 10px;
+}
+
+.log-terminal .line {
+    display: block;
+}
+
+/* Status notifications */
+.log-status-ok {
+    color: #4CAF50;
+}
+
+.log-status-err {
+    color: #f44336;
+}
+
+/* Action buttons row — minimal style matching ESP Web Tools */
+.log-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 16px;
+}
+
+.log-action-btn {
+    background: none;
+    border: none;
+    color: var(--accent-orange);
+    font-family: inherit;
+    font-size: 13px;
+    font-weight: 600;
+    cursor: pointer;
+    padding: 4px 8px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.log-action-btn:hover {
+    opacity: 0.8;
+}
+
+.log-footer {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 8px 0;
+}
+
+.log-follow-toggle {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.log-follow-toggle .toggle-label {
+    margin: 0;
+}
+
+/* Fullscreen overlay */
+.log-fullscreen {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: #1c1c1c;
+    z-index: 9999;
+    display: flex;
+    flex-direction: column;
+}
+
+.log-fullscreen-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 12px 16px;
+    background: #2d2d2d;
+    color: #ddd;
+    font-weight: 600;
+}
+
+.log-fullscreen-actions {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+}
+
+.log-fullscreen-body {
+    flex: 1;
+    overflow-y: auto;
+    padding: 16px;
+    color: #ddd;
+    font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace;
+    font-size: 13px;
+    line-height: 1.45;
+    white-space: pre-wrap;
+    overflow-wrap: break-word;
+}
+
+
+/* ==========  36. Media Queries  ============================================ */
 
 @media (max-width: 425px) {
     .game-action-btn .action-label {

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -286,6 +286,31 @@
             </div>
         </div>
 
+        <!-- Logs Section -->
+        <div class="settings-section">
+            <div class="section-header" onclick="toggleSection('logs')">
+                <span class="section-icon" id="logs-icon">▶</span>
+                <h3>Logs</h3>
+            </div>
+            <div class="section-content" id="logs-content">
+                <div id="log-terminal" class="log-terminal custom-scrollbar"></div>
+                <div class="log-footer">
+                    <div class="log-follow-toggle">
+                        <label class="toggle-label">Auto-follow</label>
+                        <label class="toggle-switch">
+                            <input type="checkbox" id="logAutoFollow" checked onchange="toggleAutoFollow()">
+                            <span class="toggle-slider"></span>
+                        </label>
+                    </div>
+                    <div class="log-actions">
+                        <button class="log-action-btn" onclick="resetDevice()">Reset Device</button>
+                        <button class="log-action-btn" onclick="copyLogs()">Copy Logs</button>
+                        <button class="log-action-btn" onclick="openLogsFullscreen()">Fullscreen</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+
         <!-- Update Available Popup Overlay -->
         <div class="update-overlay" id="updateOverlay">
             <div class="update-popup">
@@ -369,7 +394,8 @@
             lichess: false,
             board: false,
             hwconfig: false,
-            ota: false
+            ota: false,
+            logs: false
         };
 
         function toggleSection(name) {
@@ -398,6 +424,15 @@
             } else {
                 content.classList.remove('expanded');
                 icon.textContent = '▶';
+            }
+
+            // Auto-connect/disconnect logs WebSocket with section expand/collapse
+            if (name === 'logs') {
+                if (sectionStates.logs) {
+                    connectLogsWebSocket();
+                } else {
+                    disconnectLogsWebSocket();
+                }
             }
         }
 
@@ -965,6 +1000,192 @@
             xhr.setRequestHeader('Content-Type', 'application/octet-stream');
             xhr.setRequestHeader('X-File-Name', file.name);
             xhr.send(file);
+        }
+
+        // ========== Logs ==========
+        let logsWs = null;
+        let logsReconnectTimer = null;
+        let logsAutoFollow = true;
+        const logTerminal = document.getElementById('log-terminal');
+
+        function toggleAutoFollow() {
+            logsAutoFollow = document.getElementById('logAutoFollow').checked;
+            if (logsAutoFollow) {
+                logTerminal.scrollTop = logTerminal.scrollHeight;
+            }
+        }
+
+        function connectLogsWebSocket() {
+            if (logsWs && logsWs.readyState !== WebSocket.CLOSED) return;
+
+            const wsUrl = `ws://${window.location.host}/ws/logs`;
+            logsWs = new WebSocket(wsUrl);
+
+            logsWs.onopen = function () {
+                appendLogStatus('Connected', true);
+            };
+
+            logsWs.onmessage = function (event) {
+                appendLogText(event.data);
+            };
+
+            logsWs.onclose = function () {
+                appendLogStatus('Disconnected', false);
+                logsWs = null;
+                // Auto-reconnect if section is still open
+                if (sectionStates.logs) {
+                    logsReconnectTimer = setTimeout(connectLogsWebSocket, 3000);
+                }
+            };
+
+            logsWs.onerror = function () {
+                // onclose fires after this — no separate handling needed
+            };
+        }
+
+        function disconnectLogsWebSocket() {
+            if (logsReconnectTimer) {
+                clearTimeout(logsReconnectTimer);
+                logsReconnectTimer = null;
+            }
+            if (logsWs) {
+                logsWs.close();
+                logsWs = null;
+            }
+        }
+
+        function appendLogText(text) {
+            const span = document.createElement('span');
+            span.className = 'line';
+            span.textContent = text;
+            logTerminal.appendChild(span);
+            autoScroll();
+            trimLog();
+        }
+
+        function appendLogStatus(message, isOk) {
+            const span = document.createElement('span');
+            span.className = 'line ' + (isOk ? 'log-status-ok' : 'log-status-err');
+            span.textContent = '--- ' + message + ' ---\n';
+            logTerminal.appendChild(span);
+            autoScroll();
+        }
+
+        function autoScroll() {
+            if (logsAutoFollow) logTerminal.scrollTop = logTerminal.scrollHeight;
+        }
+
+        function trimLog() {
+            while (logTerminal.childElementCount > 2000) {
+                logTerminal.removeChild(logTerminal.firstChild);
+            }
+        }
+
+        function copyLogs() {
+            var text = logTerminal.innerText;
+            if (navigator.clipboard && window.isSecureContext) {
+                navigator.clipboard.writeText(text).then(function () {
+                    showAlert('Logs copied to clipboard');
+                });
+            } else {
+                var ta = document.createElement('textarea');
+                ta.value = text;
+                ta.style.position = 'fixed';
+                ta.style.left = '-9999px';
+                document.body.appendChild(ta);
+                ta.select();
+                document.execCommand('copy');
+                document.body.removeChild(ta);
+                showAlert('Logs copied to clipboard');
+            }
+        }
+
+        async function resetDevice() {
+            if (!await showConfirm('Reboot the ESP32? Active games will be interrupted.')) return;
+            fetch('/reboot', { method: 'POST' }).then(function () {
+                appendLogStatus('Reset command sent', true);
+            });
+        }
+
+        function openLogsFullscreen() {
+            const overlay = document.createElement('div');
+            overlay.className = 'log-fullscreen';
+
+            const header = document.createElement('div');
+            header.className = 'log-fullscreen-header';
+            header.innerHTML = '<span>Logs</span>';
+
+            const headerActions = document.createElement('div');
+            headerActions.className = 'log-fullscreen-actions';
+
+            // Auto-follow toggle
+            var followWrap = document.createElement('div');
+            followWrap.className = 'log-follow-toggle';
+            var followLabel = document.createElement('label');
+            followLabel.className = 'toggle-label';
+            followLabel.textContent = 'Auto-follow';
+            var toggleLabel = document.createElement('label');
+            toggleLabel.className = 'toggle-switch';
+            var fsCheckbox = document.createElement('input');
+            fsCheckbox.type = 'checkbox';
+            fsCheckbox.checked = logsAutoFollow;
+            fsCheckbox.onchange = function () {
+                document.getElementById('logAutoFollow').checked = fsCheckbox.checked;
+                toggleAutoFollow();
+                if (logsAutoFollow) body.scrollTop = body.scrollHeight;
+            };
+            var slider = document.createElement('span');
+            slider.className = 'toggle-slider';
+            toggleLabel.appendChild(fsCheckbox);
+            toggleLabel.appendChild(slider);
+            followWrap.appendChild(followLabel);
+            followWrap.appendChild(toggleLabel);
+            headerActions.appendChild(followWrap);
+
+            // Reset button
+            var resetBtn = document.createElement('button');
+            resetBtn.className = 'log-action-btn';
+            resetBtn.textContent = 'Reset Device';
+            resetBtn.onclick = resetDevice;
+            headerActions.appendChild(resetBtn);
+
+            // Copy button
+            var copyBtn = document.createElement('button');
+            copyBtn.className = 'log-action-btn';
+            copyBtn.textContent = 'Copy Logs';
+            copyBtn.onclick = copyLogs;
+            headerActions.appendChild(copyBtn);
+
+            // Close button
+            var closeBtn = document.createElement('button');
+            closeBtn.className = 'log-action-btn';
+            closeBtn.textContent = 'Close';
+            closeBtn.onclick = function () { overlay.remove(); };
+            headerActions.appendChild(closeBtn);
+
+            header.appendChild(headerActions);
+
+            const body = document.createElement('div');
+            body.className = 'log-fullscreen-body custom-scrollbar';
+            body.innerHTML = logTerminal.innerHTML;
+
+            overlay.appendChild(header);
+            overlay.appendChild(body);
+            document.body.appendChild(overlay);
+
+            if (logsAutoFollow) body.scrollTop = body.scrollHeight;
+
+            const observer = new MutationObserver(function () {
+                body.innerHTML = logTerminal.innerHTML;
+                if (logsAutoFollow) body.scrollTop = body.scrollHeight;
+            });
+            observer.observe(logTerminal, { childList: true });
+
+            const origRemove = overlay.remove.bind(overlay);
+            overlay.remove = function () {
+                observer.disconnect();
+                origRemove();
+            };
         }
     </script>
 </body>

--- a/src/wifi_manager_esp32.cpp
+++ b/src/wifi_manager_esp32.cpp
@@ -15,7 +15,7 @@ static const IPAddress AP_IP(200, 200, 200, 1);
 static const IPAddress AP_GATEWAY(200, 200, 200, 1);
 static const IPAddress AP_SUBNET(255, 255, 255, 0);
 
-WiFiManagerESP32::WiFiManagerESP32(BoardDriver* bd, MoveHistory* mh) : boardDriver(bd), moveHistory(mh), server(HTTP_PORT), gameMode("0"), lichessToken(""), botConfig(), scanAllChannels(false), profileCount(0), connectedProfileIndex(-1), scanResults(nullptr), scanResultCount(0), currentFen(INITIAL_FEN), hasPendingEdit(false), hasPendingResign(false), hasPendingDraw(false), pendingResignColor('?'), promotion{}, lastBoardPollTime(0), boardEvaluation(0.0f), otaUpdater(bd), autoOtaEnabled(false), otaChecked(false) {
+WiFiManagerESP32::WiFiManagerESP32(BoardDriver* bd, MoveHistory* mh) : boardDriver(bd), moveHistory(mh), server(HTTP_PORT), wsLogs("/ws/logs"), gameMode("0"), lichessToken(""), botConfig(), scanAllChannels(false), profileCount(0), connectedProfileIndex(-1), scanResults(nullptr), scanResultCount(0), currentFen(INITIAL_FEN), hasPendingEdit(false), hasPendingResign(false), hasPendingDraw(false), pendingResignColor('?'), promotion{}, lastBoardPollTime(0), boardEvaluation(0.0f), otaUpdater(bd), autoOtaEnabled(false), otaChecked(false) {
   promotion.reset();
   pendingWiFi.reset();
 }
@@ -102,6 +102,17 @@ void WiFiManagerESP32::begin() {
   server.on("/ota/status", HTTP_GET, [this](AsyncWebServerRequest* request) { this->handleOtaStatus(request); });
   server.on("/ota/settings", HTTP_POST, [this](AsyncWebServerRequest* request) { this->handleOtaSettings(request); });
   server.on("/ota/apply", HTTP_POST, [this](AsyncWebServerRequest* request) { this->handleOtaApply(request); });
+  // Reboot endpoint for "Reset Device" button
+  server.on("/reboot", HTTP_POST, [](AsyncWebServerRequest* request) {
+    request->send(200, "text/plain", "Rebooting...");
+    xTaskCreate(
+        [](void*) {
+          delay(500);
+          ESP.restart();
+          vTaskDelete(NULL);
+        },
+        "reboot", 2048, NULL, 1, NULL);
+  });
   // OTA manual upload endpoints - JS sends raw binary body (application/octet-stream), so only the body handler (3rd callback) fires; the multipart file handler (2nd) is unused.
   server.on(
       "/ota/upload/firmware", HTTP_POST,
@@ -122,6 +133,18 @@ void WiFiManagerESP32::begin() {
   server.onNotFound([](AsyncWebServerRequest* request) { request->send(404, "text/plain", "Not Found"); });
   server.begin();
   Serial.println("Web server started on port: " + String(HTTP_PORT));
+
+  // Set up WebSocket for logs
+  wsLogs.onEvent([](AsyncWebSocket* server,
+                    AsyncWebSocketClient* client,
+                    AwsEventType type,
+                    void* arg, uint8_t* data, size_t len) {
+      if (type == WS_EVT_CONNECT) {
+          Logger.sendHistory(client->id());
+      }
+  });
+  server.addHandler(&wsLogs);
+  Logger.setWebSocket(&wsLogs);
 
   xTaskCreate(pendingWiFiBackgroundTask, "WiFi_Pending_Task", 8192, this, 4, &pendingWiFiTaskHandle);
 }
@@ -1132,8 +1155,18 @@ void WiFiManagerESP32::dnsTask(void* param) {
 
 void WiFiManagerESP32::pendingWiFiBackgroundTask(void* param) {
   WiFiManagerESP32* manager = static_cast<WiFiManagerESP32*>(param);
+  unsigned long lastMaintenance = 0;
   while (true) {
     manager->checkPendingWiFi();
+    Logger.flush();
+
+    // Every ~5 seconds: ping clients and free memory from dead WS clients
+    if (millis() - lastMaintenance >= 5000) {
+      lastMaintenance = millis();
+      Logger.ping();
+      Logger.cleanup();
+    }
+
     vTaskDelay(pdMS_TO_TICKS(50));
   }
   vTaskDelete(nullptr);

--- a/src/wifi_manager_esp32.h
+++ b/src/wifi_manager_esp32.h
@@ -58,6 +58,7 @@ class WiFiManagerESP32 {
  private:
   AsyncWebServer server;
   DNSServer dnsServer;
+  AsyncWebSocket wsLogs;
 
   TaskHandle_t pendingWiFiTaskHandle = nullptr;
   static void pendingWiFiBackgroundTask(void* param);


### PR DESCRIPTION
@joojoooo - hopefully this is a little more reasonable! 

## Summary
- Stream ESP32 serial logs to the browser in real-time via WebSocket (`/ws/logs`)
- Log terminal UI with auto-follow, copy to clipboard, and fullscreen mode
- Circular log buffer maintains history for late-joining clients
- Device reboot button
- WebSocket auto-connects when Logs section is expanded, disconnects when collapsed

## New files
- `src/log_buffer.h` / `src/log_buffer.cpp` — Ring buffer with FreeRTOS mutex, WebSocket integration, and `printf`-macro interception

## Modified files
- `platformio.ini` — Add build flag to include log buffer header
- `src/wifi_manager_esp32.h/.cpp` — WebSocket handler, reboot endpoint, periodic log flush/cleanup
- `src/web/index.html` — Logs section UI and JavaScript
- `src/web/css/styles.css` — Log terminal, fullscreen overlay, and z-index adjustment for modals

## AI Disclosure
This PR was developed with assistance from Claude (Anthropic, claude-opus-4-6). The implementation — including the log buffer, WebSocket integration, web UI, and CSS — was generated by Claude based on design direction and review feedback from the contributor. All code was reviewed, understood, and tested on hardware by the contributor before submission.

## Test plan
- [ ] Flash firmware and open web UI
- [ ] Expand Logs section — verify WebSocket connects and logs stream
- [ ] Collapse section — verify WebSocket disconnects
- [ ] Test auto-follow toggle on/off
- [ ] Test "Copy Logs" button
- [ ] Test fullscreen mode (open, scroll, close)
- [ ] Test "Reset Device" button — confirm reboot and reconnect
- [ ] Power cycle ESP32 — verify "Disconnected" status and auto-reconnect
- [ ] Confirm modals still appear above fullscreen log view