### PR TITLE
Add Checkers game mode with Stockchicken AI opponent

### DIFF
--- a/src/checkers_bot_game.cpp
+++ b/src/checkers_bot_game.cpp
@@ -1,0 +1,115 @@
+#include "checkers_bot_game.h"
+#include "checkers_ui.h"
+#include "led_colors.h"
+#include "web_logger.h"
+#include <Arduino.h>
+#include <string.h>
+
+const char CheckersBotGame::INITIAL_BOARD[8][8] = {
+    {' ', 'b', ' ', 'b', ' ', 'b', ' ', 'b'},
+    {'b', ' ', 'b', ' ', 'b', ' ', 'b', ' '},
+    {' ', 'b', ' ', 'b', ' ', 'b', ' ', 'b'},
+    {' ', ' ', ' ', ' ', ' ', ' ', ' ', ' '},
+    {' ', ' ', ' ', ' ', ' ', ' ', ' ', ' '},
+    {'w', ' ', 'w', ' ', 'w', ' ', 'w', ' '},
+    {' ', 'w', ' ', 'w', ' ', 'w', ' ', 'w'},
+    {'w', ' ', 'w', ' ', 'w', ' ', 'w', ' '}};
+
+CheckersBotGame::CheckersBotGame(BoardDriver* bd, const StockchickenConfig& config) : boardDriver(bd), bot(config), currentTurn('w'), gameOver(false) {}
+
+void CheckersBotGame::begin() {
+  webLog.println("=== Starting Checkers vs Stockchicken ===");
+  webLog.println("You play White (near rows). Stockchicken plays Black.");
+  initializeBoard();
+
+  webLog.println("Set up checkers: 12 white pieces on the near rows, 12 black on the far rows (dark squares only)");
+  CheckersUI::waitForBoardSetup(boardDriver, INITIAL_BOARD);
+  webLog.println("Checkers board ready. White moves first.");
+}
+
+void CheckersBotGame::initializeBoard() {
+  memcpy(board, INITIAL_BOARD, sizeof(INITIAL_BOARD));
+  currentTurn = 'w';
+  gameOver = false;
+}
+
+void CheckersBotGame::update() {
+  if (gameOver)
+    return;
+
+  boardDriver->readSensors();
+  bool completed = (currentTurn == 'w') ? CheckersUI::playHumanTurn(boardDriver, engine, board, 'w', quitState) : playBotTurn();
+  boardDriver->updateSensorPrev();
+
+  if (!completed) {
+    gameOver = true;
+    return;
+  }
+
+  char next = CheckersUI::oppositeColor(currentTurn);
+  if (engine.hasNoPieces(board, next) || !engine.hasAnyLegalMove(board, next)) {
+    CheckersUI::announceGameOver(boardDriver, currentTurn);
+    gameOver = true;
+  } else {
+    currentTurn = next;
+  }
+}
+
+bool CheckersBotGame::playBotTurn() {
+  Stockchicken::Turn turn;
+  if (!bot.chooseTurn(board, 'b', turn)) {
+    // No legal move - the game-over check in update() will catch this.
+    return true;
+  }
+
+  for (int i = 0; i < turn.stepCount; i++) {
+    const Stockchicken::Step& step = turn.steps[i];
+    const CheckersEngine::Move& move = step.move;
+    char piece = board[step.fromRow][step.fromCol];
+    bool promotes = engine.isPromotion(piece, move.toRow);
+
+    webLog.printf("Stockchicken: %c%d -> %c%d%s\n", (char)('a' + step.fromCol), 8 - step.fromRow, (char)('a' + move.toCol), 8 - move.toRow, move.isCapture ? " (capture)" : "");
+
+    // Show the move: cyan = pick this piece up, green/blue = where to place
+    // it (blue if it crowns), red = piece to remove on a capture.
+    boardDriver->acquireLEDs();
+    boardDriver->clearAllLEDs(false);
+    boardDriver->setSquareLED(step.fromRow, step.fromCol, LedColors::Cyan);
+    boardDriver->setSquareLED(move.toRow, move.toCol, promotes ? LedColors::Blue : LedColors::Green);
+    if (move.isCapture)
+      boardDriver->setSquareLED(move.capturedRow, move.capturedCol, LedColors::Red);
+    boardDriver->showLEDs();
+    boardDriver->releaseLEDs();
+
+    // Wait for the human to physically perform this step.
+    for (;;) {
+      boardDriver->readSensors();
+
+      if (CheckersUI::checkPhysicalQuit(boardDriver, quitState)) {
+        boardDriver->clearAllLEDs();
+        return false;
+      }
+
+      bool lifted = !boardDriver->getSensorState(step.fromRow, step.fromCol);
+      bool placed = boardDriver->getSensorState(move.toRow, move.toCol);
+      bool captureCleared = !move.isCapture || !boardDriver->getSensorState(move.capturedRow, move.capturedCol);
+      if (lifted && placed && captureCleared)
+        break;
+      delay(SENSOR_READ_DELAY_MS);
+    }
+
+    board[step.fromRow][step.fromCol] = ' ';
+    if (move.isCapture)
+      board[move.capturedRow][move.capturedCol] = ' ';
+    board[move.toRow][move.toCol] = promotes ? 'B' : piece;
+    if (promotes)
+      webLog.println("Stockchicken: piece crowned!");
+
+    boardDriver->acquireLEDs();
+    boardDriver->clearAllLEDs();
+    boardDriver->releaseLEDs();
+    boardDriver->updateSensorPrev();
+  }
+
+  return true;
+}

--- a/src/checkers_bot_game.h
+++ b/src/checkers_bot_game.h
@@ -1,0 +1,42 @@
+#ifndef CHECKERS_BOT_GAME_H
+#define CHECKERS_BOT_GAME_H
+
+#include "board_driver.h"
+#include "checkers_engine.h"
+#include "checkers_ui.h"
+#include "stockchicken.h"
+
+// ---------------------------
+// Checkers Game Mode (player vs Stockchicken)
+// ---------------------------
+// The human always plays white (the near rows); Stockchicken plays black.
+// Human turns reuse the same sensor/LED flow as CheckersGame (CheckersUI).
+// On the AI's turn, Stockchicken picks a full turn and the board shows it
+// the same way ChessBot shows computer moves: cyan on the square to lift,
+// green/blue on where to place it (blue if it crowns), red on a captured
+// piece to remove - then waits for the human to perform it physically.
+class CheckersBotGame {
+ public:
+  CheckersBotGame(BoardDriver* bd, const StockchickenConfig& config);
+
+  void begin();
+  void update();
+  bool isGameOver() const { return gameOver; }
+
+ private:
+  BoardDriver* boardDriver;
+  CheckersEngine engine;
+  Stockchicken bot;
+  CheckersUI::QuitGestureState quitState;
+
+  char board[8][8];
+  char currentTurn; // 'w' (human) or 'b' (Stockchicken)
+  bool gameOver;
+
+  static const char INITIAL_BOARD[8][8];
+
+  void initializeBoard();
+  bool playBotTurn(); // returns false if the quit gesture fired
+};
+
+#endif // CHECKERS_BOT_GAME_H

--- a/src/checkers_engine.cpp
+++ b/src/checkers_engine.cpp
@@ -1,0 +1,137 @@
+#include "checkers_engine.h"
+
+namespace {
+struct DirSet {
+  int dirs[4][2];
+  int count;
+};
+
+// Diagonal step directions {dRow, dCol} a piece is allowed to move/capture in.
+DirSet directionsFor(char piece) {
+  if (CheckersEngine::isKing(piece))
+    return {{{-1, -1}, {-1, 1}, {1, -1}, {1, 1}}, 4};
+  if (piece == 'w')
+    return {{{-1, -1}, {-1, 1}, {0, 0}, {0, 0}}, 2}; // white pieces move toward row 0
+  return {{{1, -1}, {1, 1}, {0, 0}, {0, 0}}, 2};      // black pieces move toward row 7
+}
+} // namespace
+
+char CheckersEngine::getPieceColor(char piece) {
+  if (piece == ' ')
+    return ' ';
+  return (piece == 'w' || piece == 'W') ? 'w' : 'b';
+}
+
+bool CheckersEngine::isKing(char piece) {
+  return piece == 'W' || piece == 'B';
+}
+
+bool CheckersEngine::isOnBoard(int row, int col) {
+  return row >= 0 && row < 8 && col >= 0 && col < 8;
+}
+
+void CheckersEngine::getCapturesForSquare(const char board[8][8], int row, int col, char color, Move moves[MAX_MOVES], int& moveCount) const {
+  moveCount = 0;
+  char piece = board[row][col];
+  if (getPieceColor(piece) != color)
+    return;
+
+  DirSet dirs = directionsFor(piece);
+  for (int i = 0; i < dirs.count; i++) {
+    int midRow = row + dirs.dirs[i][0];
+    int midCol = col + dirs.dirs[i][1];
+    int toRow = row + 2 * dirs.dirs[i][0];
+    int toCol = col + 2 * dirs.dirs[i][1];
+
+    if (!isOnBoard(toRow, toCol))
+      continue;
+
+    char midPiece = board[midRow][midCol];
+    if (midPiece == ' ' || getPieceColor(midPiece) == color)
+      continue;
+
+    if (board[toRow][toCol] != ' ')
+      continue;
+
+    moves[moveCount++] = {toRow, toCol, true, midRow, midCol};
+  }
+}
+
+void CheckersEngine::getNonCaptureMoves(const char board[8][8], int row, int col, char color, Move moves[MAX_MOVES], int& moveCount) const {
+  moveCount = 0;
+  char piece = board[row][col];
+  if (getPieceColor(piece) != color)
+    return;
+
+  DirSet dirs = directionsFor(piece);
+  for (int i = 0; i < dirs.count; i++) {
+    int toRow = row + dirs.dirs[i][0];
+    int toCol = col + dirs.dirs[i][1];
+
+    if (!isOnBoard(toRow, toCol) || board[toRow][toCol] != ' ')
+      continue;
+
+    moves[moveCount++] = {toRow, toCol, false, -1, -1};
+  }
+}
+
+bool CheckersEngine::hasAnyCapture(const char board[8][8], char color) const {
+  Move moves[MAX_MOVES];
+  int moveCount;
+  for (int r = 0; r < 8; r++)
+    for (int c = 0; c < 8; c++) {
+      if (getPieceColor(board[r][c]) != color)
+        continue;
+      getCapturesForSquare(board, r, c, color, moves, moveCount);
+      if (moveCount > 0)
+        return true;
+    }
+  return false;
+}
+
+void CheckersEngine::getLegalMoves(const char board[8][8], int row, int col, char color, bool mustCapture, Move moves[MAX_MOVES], int& moveCount) const {
+  moveCount = 0;
+  if (getPieceColor(board[row][col]) != color)
+    return;
+
+  getCapturesForSquare(board, row, col, color, moves, moveCount);
+  if (moveCount > 0 || mustCapture)
+    return; // this piece has a capture, or another piece must capture instead
+
+  getNonCaptureMoves(board, row, col, color, moves, moveCount);
+}
+
+void CheckersEngine::getContinuationCaptures(const char board[8][8], int row, int col, char color, Move moves[MAX_MOVES], int& moveCount) const {
+  getCapturesForSquare(board, row, col, color, moves, moveCount);
+}
+
+bool CheckersEngine::isPromotion(char piece, int toRow) const {
+  if (isKing(piece))
+    return false;
+  return (piece == 'w' && toRow == 0) || (piece == 'b' && toRow == 7);
+}
+
+bool CheckersEngine::hasNoPieces(const char board[8][8], char color) const {
+  for (int r = 0; r < 8; r++)
+    for (int c = 0; c < 8; c++)
+      if (getPieceColor(board[r][c]) == color)
+        return false;
+  return true;
+}
+
+bool CheckersEngine::hasAnyLegalMove(const char board[8][8], char color) const {
+  if (hasAnyCapture(board, color))
+    return true;
+
+  Move moves[MAX_MOVES];
+  int moveCount;
+  for (int r = 0; r < 8; r++)
+    for (int c = 0; c < 8; c++) {
+      if (getPieceColor(board[r][c]) != color)
+        continue;
+      getLegalMoves(board, r, c, color, false, moves, moveCount);
+      if (moveCount > 0)
+        return true;
+    }
+  return false;
+}

--- a/src/checkers_engine.h
+++ b/src/checkers_engine.h
@@ -1,0 +1,74 @@
+#ifndef CHECKERS_ENGINE_H
+#define CHECKERS_ENGINE_H
+
+// ---------------------------
+// Checkers Rules Engine (standard American/English draughts)
+// ---------------------------
+// Board notation - independent of the chess engine's:
+//   ' ' = empty square
+//   'w' / 'b' = white / black man
+//   'W' / 'B' = white / black king
+//
+// Board orientation matches the chess board: row 0 = far rank, row 7 =
+// near rank. White's pieces start on rows 5-7 and move toward row 0;
+// black's pieces start on rows 0-2 and move toward row 7.
+//
+// Rules implemented:
+//  - Pieces move and capture diagonally forward only (not backward).
+//  - Kings move and capture one diagonal step in any of the 4 directions
+//    (no "flying" kings).
+//  - Captures are mandatory: if any piece of the side to move can capture,
+//    only capture moves are legal, and only for pieces that have one.
+//  - Multi-jump continuation is mandatory: after a capture, the same piece
+//    must keep capturing if another jump is available from its new square.
+//  - A man that lands on the back row is crowned and its turn ends
+//    immediately, even if a further jump would otherwise be available.
+class CheckersEngine {
+ public:
+  static constexpr int MAX_MOVES = 4;
+
+  // A single move/jump destination for a piece. `isCapture` indicates a
+  // jump, with the captured piece located at (capturedRow, capturedCol).
+  struct Move {
+    int toRow, toCol;
+    bool isCapture;
+    int capturedRow, capturedCol;
+  };
+
+  // 'w'/'b' for either color of man or king, ' ' for an empty square.
+  static char getPieceColor(char piece);
+  static bool isKing(char piece);
+  static bool isOnBoard(int row, int col);
+
+  // True if `color` has at least one capturing move available anywhere on the board.
+  bool hasAnyCapture(const char board[8][8], char color) const;
+
+  // Legal destinations for the piece at (row, col), applying the mandatory
+  // capture rule for `color` as a whole: if `mustCapture` is true, only
+  // capture moves are returned, and only for pieces that have one (pieces
+  // without a capture return zero moves). Pass the result of
+  // hasAnyCapture(board, color), computed once per position rather than
+  // once per piece.
+  void getLegalMoves(const char board[8][8], int row, int col, char color, bool mustCapture, Move moves[MAX_MOVES], int& moveCount) const;
+
+  // Further captures available for a piece that just landed at (row, col),
+  // used to enforce mandatory multi-jump continuation. Unlike getLegalMoves,
+  // this only looks at this piece - other pieces' captures are irrelevant
+  // mid-sequence.
+  void getContinuationCaptures(const char board[8][8], int row, int col, char color, Move moves[MAX_MOVES], int& moveCount) const;
+
+  // True if a piece landing on toRow would be crowned.
+  bool isPromotion(char piece, int toRow) const;
+
+  // True if `color` has no pieces left on the board.
+  bool hasNoPieces(const char board[8][8], char color) const;
+
+  // True if `color` has at least one legal move anywhere (mandatory-capture aware).
+  bool hasAnyLegalMove(const char board[8][8], char color) const;
+
+ private:
+  void getCapturesForSquare(const char board[8][8], int row, int col, char color, Move moves[MAX_MOVES], int& moveCount) const;
+  void getNonCaptureMoves(const char board[8][8], int row, int col, char color, Move moves[MAX_MOVES], int& moveCount) const;
+};
+
+#endif // CHECKERS_ENGINE_H

--- a/src/checkers_game.cpp
+++ b/src/checkers_game.cpp
@@ -1,0 +1,52 @@
+#include "checkers_game.h"
+#include "checkers_ui.h"
+#include "web_logger.h"
+#include <string.h>
+
+const char CheckersGame::INITIAL_BOARD[8][8] = {
+    {' ', 'b', ' ', 'b', ' ', 'b', ' ', 'b'},
+    {'b', ' ', 'b', ' ', 'b', ' ', 'b', ' '},
+    {' ', 'b', ' ', 'b', ' ', 'b', ' ', 'b'},
+    {' ', ' ', ' ', ' ', ' ', ' ', ' ', ' '},
+    {' ', ' ', ' ', ' ', ' ', ' ', ' ', ' '},
+    {'w', ' ', 'w', ' ', 'w', ' ', 'w', ' '},
+    {' ', 'w', ' ', 'w', ' ', 'w', ' ', 'w'},
+    {'w', ' ', 'w', ' ', 'w', ' ', 'w', ' '}};
+
+CheckersGame::CheckersGame(BoardDriver* bd) : boardDriver(bd), currentTurn('w'), gameOver(false) {}
+
+void CheckersGame::begin() {
+  webLog.println("=== Starting Checkers Mode ===");
+  initializeBoard();
+
+  webLog.println("Set up checkers: 12 white pieces on the near rows, 12 black on the far rows (dark squares only)");
+  CheckersUI::waitForBoardSetup(boardDriver, INITIAL_BOARD);
+  webLog.println("Checkers board ready. White moves first.");
+}
+
+void CheckersGame::initializeBoard() {
+  memcpy(board, INITIAL_BOARD, sizeof(INITIAL_BOARD));
+  currentTurn = 'w';
+  gameOver = false;
+}
+
+void CheckersGame::update() {
+  if (gameOver)
+    return;
+
+  boardDriver->readSensors();
+  if (!CheckersUI::playHumanTurn(boardDriver, engine, board, currentTurn, quitState)) {
+    boardDriver->updateSensorPrev();
+    gameOver = true;
+    return;
+  }
+  boardDriver->updateSensorPrev();
+
+  char next = CheckersUI::oppositeColor(currentTurn);
+  if (engine.hasNoPieces(board, next) || !engine.hasAnyLegalMove(board, next)) {
+    CheckersUI::announceGameOver(boardDriver, currentTurn);
+    gameOver = true;
+  } else {
+    currentTurn = next;
+  }
+}

--- a/src/checkers_game.h
+++ b/src/checkers_game.h
@@ -1,0 +1,36 @@
+#ifndef CHECKERS_GAME_H
+#define CHECKERS_GAME_H
+
+#include "board_driver.h"
+#include "checkers_engine.h"
+#include "checkers_ui.h"
+
+// ---------------------------
+// Checkers Game Mode (local player vs player)
+// ---------------------------
+// Standalone mode independent of the chess classes - depends only on
+// BoardDriver/CheckersEngine plus the shared CheckersUI helpers for the
+// sensor/LED turn logic.
+class CheckersGame {
+ public:
+  explicit CheckersGame(BoardDriver* bd);
+
+  void begin();
+  void update();
+  bool isGameOver() const { return gameOver; }
+
+ private:
+  BoardDriver* boardDriver;
+  CheckersEngine engine;
+  CheckersUI::QuitGestureState quitState;
+
+  char board[8][8];
+  char currentTurn; // 'w' or 'b'
+  bool gameOver;
+
+  static const char INITIAL_BOARD[8][8];
+
+  void initializeBoard();
+};
+
+#endif // CHECKERS_GAME_H

--- a/src/checkers_ui.cpp
+++ b/src/checkers_ui.cpp
@@ -1,0 +1,295 @@
+#include "checkers_ui.h"
+#include "led_colors.h"
+#include "web_logger.h"
+#include <Arduino.h>
+
+namespace CheckersUI {
+
+void waitForBoardSetup(BoardDriver* boardDriver, const char initial[8][8]) {
+  boardDriver->acquireLEDs();
+  bool allCorrect = false;
+  while (!allCorrect) {
+    boardDriver->readSensors();
+    allCorrect = true;
+    boardDriver->clearAllLEDs(false);
+
+    for (int row = 0; row < 8; row++) {
+      for (int col = 0; col < 8; col++) {
+        bool shouldHavePiece = (initial[row][col] != ' ');
+        bool hasPiece = boardDriver->getSensorState(row, col);
+        if (shouldHavePiece == hasPiece)
+          continue;
+
+        allCorrect = false;
+        if (shouldHavePiece && !hasPiece)
+          boardDriver->setSquareLED(row, col, initial[row][col] == 'w' ? LedColors::White : LedColors::Blue);
+        else
+          boardDriver->setSquareLED(row, col, LedColors::Red);
+      }
+    }
+
+    boardDriver->showLEDs();
+    if (!allCorrect)
+      delay(SENSOR_READ_DELAY_MS);
+  }
+  boardDriver->clearAllLEDs();
+  boardDriver->releaseLEDs();
+  boardDriver->fireworkAnimation();
+  boardDriver->updateSensorPrev();
+}
+
+bool checkPhysicalQuit(BoardDriver* boardDriver, QuitGestureState& state) {
+  bool cornerA = boardDriver->getSensorState(QUIT_ROW_A, QUIT_COL_A);
+  bool cornerB = boardDriver->getSensorState(QUIT_ROW_B, QUIT_COL_B);
+
+  if (!(cornerA && cornerB)) {
+    state.armed = true;
+    return false;
+  }
+  if (!state.armed)
+    return false; // both corners occupied, but not seen empty since last trigger - ignore
+  state.armed = false;
+
+  webLog.println("Checkers: quit gesture detected (pieces on both far corners). Hold to confirm...");
+
+  constexpr unsigned long QUIT_HOLD_MS = 2000;
+  constexpr int QUIT_PROGRESS_STEPS = 8;
+
+  boardDriver->acquireLEDs();
+  boardDriver->clearAllLEDs(false);
+
+  unsigned long start = millis();
+  int shownProgress = -1;
+  while (millis() - start < QUIT_HOLD_MS) {
+    boardDriver->readSensors();
+    if (!boardDriver->getSensorState(QUIT_ROW_A, QUIT_COL_A) || !boardDriver->getSensorState(QUIT_ROW_B, QUIT_COL_B)) {
+      boardDriver->clearAllLEDs();
+      boardDriver->releaseLEDs();
+      webLog.println("Checkers: quit gesture aborted (a corner piece was lifted)");
+      return false;
+    }
+
+    unsigned long elapsed = millis() - start;
+    int progress = ((elapsed + 1) * QUIT_PROGRESS_STEPS) / QUIT_HOLD_MS;
+    if (progress > QUIT_PROGRESS_STEPS)
+      progress = QUIT_PROGRESS_STEPS;
+
+    if (progress != shownProgress) {
+      boardDriver->clearAllLEDs(false);
+      for (int i = 0; i < progress; i++) {
+        boardDriver->setSquareLED(7 - i, 3, LedColors::Cyan);
+        boardDriver->setSquareLED(i, 4, LedColors::Cyan);
+      }
+      boardDriver->showLEDs();
+      shownProgress = progress;
+    }
+
+    delay(SENSOR_READ_DELAY_MS);
+  }
+
+  boardDriver->clearAllLEDs();
+  boardDriver->releaseLEDs();
+  webLog.println("Checkers: quit confirmed, returning to game selection");
+  return true;
+}
+
+void highlightMovablePieces(BoardDriver* boardDriver, const CheckersEngine& engine, const char board[8][8], char color) {
+  CheckersEngine::Move moves[CheckersEngine::MAX_MOVES];
+  int moveCount;
+  bool mustCapture = engine.hasAnyCapture(board, color);
+
+  boardDriver->acquireLEDs();
+  boardDriver->clearAllLEDs(false);
+  for (int r = 0; r < 8; r++) {
+    for (int c = 0; c < 8; c++) {
+      if (CheckersEngine::getPieceColor(board[r][c]) != color)
+        continue;
+      engine.getLegalMoves(board, r, c, color, mustCapture, moves, moveCount);
+      if (moveCount > 0)
+        boardDriver->setSquareLED(r, c, LedColors::White);
+    }
+  }
+  boardDriver->showLEDs();
+  boardDriver->releaseLEDs();
+}
+
+void highlightDestinations(BoardDriver* boardDriver, const CheckersEngine& engine, const CheckersEngine::Move moves[], int moveCount, char piece) {
+  boardDriver->acquireLEDs();
+  boardDriver->clearAllLEDs(false);
+  for (int i = 0; i < moveCount; i++) {
+    bool promotes = engine.isPromotion(piece, moves[i].toRow);
+    boardDriver->setSquareLED(moves[i].toRow, moves[i].toCol, promotes ? LedColors::Blue : LedColors::Green);
+    if (moves[i].isCapture)
+      boardDriver->setSquareLED(moves[i].capturedRow, moves[i].capturedCol, LedColors::Red);
+  }
+  boardDriver->showLEDs();
+  boardDriver->releaseLEDs();
+}
+
+bool playHumanTurn(BoardDriver* boardDriver, const CheckersEngine& engine, char board[8][8], char color, QuitGestureState& quitState) {
+  // Loop so an aborted pickup (returned to its square) simply restarts the
+  // selection phase without recursing.
+  for (;;) {
+    highlightMovablePieces(boardDriver, engine, board, color);
+    bool mustCapture = engine.hasAnyCapture(board, color);
+
+    // --- Phase 1: monitor all squares and wait for exactly one legal pickup ---
+    // Every polling cycle, compare the logical board state against sensors.
+    // Any square that should have a piece but doesn't is "displaced". If
+    // it's the current player's piece with a legal move it's an intentional
+    // pickup; everything else - wrong colour, own piece with no legal move,
+    // a piece accidentally knocked - shows red until returned.
+    int row = -1, col = -1;
+    CheckersEngine::Move moves[CheckersEngine::MAX_MOVES];
+    int moveCount = 0;
+    bool showingRed = false;
+
+    while (row == -1) {
+      boardDriver->readSensors();
+
+      if (checkPhysicalQuit(boardDriver, quitState)) {
+        boardDriver->clearAllLEDs();
+        return false;
+      }
+
+      int legalRow = -1, legalCol = -1, legalCount = 0;
+      int illegalR[24], illegalC[24], illegalCount = 0;
+
+      for (int r = 0; r < 8; r++) {
+        for (int c = 0; c < 8; c++) {
+          if (board[r][c] == ' ' || boardDriver->getSensorState(r, c))
+            continue; // empty square or piece correctly seated
+
+          if (CheckersEngine::getPieceColor(board[r][c]) == color) {
+            CheckersEngine::Move m[CheckersEngine::MAX_MOVES];
+            int mc;
+            engine.getLegalMoves(board, r, c, color, mustCapture, m, mc);
+            if (mc > 0) {
+              legalRow = r;
+              legalCol = c;
+              memcpy(moves, m, mc * sizeof(CheckersEngine::Move));
+              moveCount = mc;
+              legalCount++;
+              continue;
+            }
+          }
+
+          illegalR[illegalCount] = r;
+          illegalC[illegalCount] = c;
+          illegalCount++;
+        }
+      }
+
+      if (illegalCount > 0) {
+        boardDriver->acquireLEDs();
+        for (int i = 0; i < illegalCount; i++)
+          boardDriver->setSquareLED(illegalR[i], illegalC[i], LedColors::Red);
+        boardDriver->showLEDs();
+        boardDriver->releaseLEDs();
+        showingRed = true;
+      } else if (showingRed) {
+        // All misplacements corrected - restore movable piece highlights
+        highlightMovablePieces(boardDriver, engine, board, color);
+        showingRed = false;
+      }
+
+      if (legalCount == 1 && illegalCount == 0) {
+        row = legalRow;
+        col = legalCol;
+        break;
+      }
+
+      delay(SENSOR_READ_DELAY_MS);
+    }
+
+    char piece = board[row][col];
+    webLog.printf("Checkers: picked up %c%d\n", (char)('a' + col), 8 - row);
+    highlightDestinations(boardDriver, engine, moves, moveCount, piece);
+
+    // --- Phase 2: resolve the move, including any forced multi-jump continuation ---
+    bool cancelled = false;
+    for (;;) {
+      int chosen = -1;
+      while (chosen == -1) {
+        boardDriver->readSensors();
+
+        if (checkPhysicalQuit(boardDriver, quitState)) {
+          boardDriver->clearAllLEDs();
+          return false;
+        }
+
+        if (boardDriver->getSensorState(row, col)) {
+          cancelled = true;
+          break;
+        }
+
+        for (int i = 0; i < moveCount; i++) {
+          const CheckersEngine::Move& m = moves[i];
+          bool landed = boardDriver->getSensorState(m.toRow, m.toCol);
+          bool captureCleared = !m.isCapture || !boardDriver->getSensorState(m.capturedRow, m.capturedCol);
+          if (landed && captureCleared) {
+            chosen = i;
+            break;
+          }
+        }
+
+        if (chosen == -1 && !cancelled)
+          delay(SENSOR_READ_DELAY_MS);
+      }
+
+      if (cancelled)
+        break;
+
+      const CheckersEngine::Move& move = moves[chosen];
+      webLog.printf("Checkers: %c%d -> %c%d%s\n", (char)('a' + col), 8 - row, (char)('a' + move.toCol), 8 - move.toRow, move.isCapture ? " (capture)" : "");
+
+      board[move.toRow][move.toCol] = piece;
+      board[row][col] = ' ';
+      if (move.isCapture)
+        board[move.capturedRow][move.capturedCol] = ' ';
+
+      boardDriver->clearAllLEDs();
+      boardDriver->blinkSquare(move.toRow, move.toCol, LedColors::Green, 1);
+      boardDriver->updateSensorPrev();
+
+      if (engine.isPromotion(piece, move.toRow)) {
+        piece = (color == 'w') ? 'W' : 'B';
+        board[move.toRow][move.toCol] = piece;
+        webLog.println("Checkers: piece crowned!");
+        boardDriver->blinkSquare(move.toRow, move.toCol, LedColors::Blue, 4);
+        break; // promotion ends the turn even mid-capture per WCDF rules
+      }
+
+      if (!move.isCapture)
+        break; // non-capture move always ends the turn
+
+      row = move.toRow;
+      col = move.toCol;
+      engine.getContinuationCaptures(board, row, col, color, moves, moveCount);
+      if (moveCount == 0)
+        break;
+
+      webLog.println("Checkers: capture again with the same piece");
+      highlightDestinations(boardDriver, engine, moves, moveCount, piece);
+    }
+
+    if (cancelled) {
+      webLog.println("Checkers: pickup cancelled");
+      boardDriver->clearAllLEDs();
+      boardDriver->updateSensorPrev();
+      continue; // restart the selection phase for the same turn
+    }
+
+    break;
+  }
+
+  boardDriver->clearAllLEDs();
+  return true;
+}
+
+void announceGameOver(BoardDriver* boardDriver, char winnerColor) {
+  webLog.printf("Checkers: %s wins!\n", winnerColor == 'w' ? "White" : "Black");
+  boardDriver->fireworkAnimation(winnerColor == 'w' ? LedColors::White : LedColors::Blue);
+}
+
+} // namespace CheckersUI

--- a/src/checkers_ui.h
+++ b/src/checkers_ui.h
@@ -1,0 +1,65 @@
+#ifndef CHECKERS_UI_H
+#define CHECKERS_UI_H
+
+#include "board_driver.h"
+#include "checkers_engine.h"
+
+// ---------------------------
+// Shared checkers board/LED helpers
+// ---------------------------
+// Free functions shared between the player-vs-player (CheckersGame) and
+// player-vs-Stockchicken (CheckersBotGame) modes, so the sensor/LED
+// plumbing for a human turn only has to live in one place.
+namespace CheckersUI {
+
+// Far corner squares used for the physical quit gesture: place a piece on
+// both simultaneously and hold to back out to game selection. These are the
+// two light/unplayable corners - (row+col) even - so they never legitimately
+// hold a checkers piece during normal play.
+constexpr int QUIT_ROW_A = 0, QUIT_COL_A = 0;
+constexpr int QUIT_ROW_B = 7, QUIT_COL_B = 7;
+
+// Tracks whether the quit gesture is "armed" - both corners must be seen
+// NOT-both-occupied at least once before the gesture can fire, so it can't
+// trigger from stale state carried over between games.
+struct QuitGestureState {
+  bool armed = false;
+};
+
+// Blocks until the physical board matches `initial`, guiding setup with
+// White/Blue (missing piece) and Red (extra piece) LEDs, then plays the
+// "ready" firework animation.
+void waitForBoardSetup(BoardDriver* boardDriver, const char initial[8][8]);
+
+// Checks the quit gesture (pieces on both QUIT_ROW_A/QUIT_COL_A and
+// QUIT_ROW_B/QUIT_COL_B). Call every polling cycle from any blocking wait
+// loop. Returns true once the ~2s hold (with a cyan countdown, mirroring
+// ChessGame's resign/draw gesture) completes; false otherwise, including
+// while the hold is in progress (it blocks internally until completion or
+// abort) or when the gesture isn't currently armed.
+bool checkPhysicalQuit(BoardDriver* boardDriver, QuitGestureState& state);
+
+// Lights every `color` piece that has a legal move (mandatory-capture
+// aware) white.
+void highlightMovablePieces(BoardDriver* boardDriver, const CheckersEngine& engine, const char board[8][8], char color);
+
+// Clears the board's LEDs and lights the given destinations green, or blue
+// for destinations that would crown `piece`.
+void highlightDestinations(BoardDriver* boardDriver, const CheckersEngine& engine, const CheckersEngine::Move moves[], int moveCount, char piece);
+
+// Plays one full turn for `color`: lights movable pieces, waits for a
+// pickup (flagging illegal pickups red until returned), then resolves the
+// move including any forced multi-jump continuation. Mutates `board` and
+// leaves the board's LEDs cleared. Does not touch whose-turn-it-is or
+// game-over state - that's the caller's responsibility. Returns false (and
+// leaves `board` mid-turn) if the quit gesture fires instead of a move.
+bool playHumanTurn(BoardDriver* boardDriver, const CheckersEngine& engine, char board[8][8], char color, QuitGestureState& quitState);
+
+// Fires the win animation (white or blue) for `winnerColor`.
+void announceGameOver(BoardDriver* boardDriver, char winnerColor);
+
+inline char oppositeColor(char color) { return color == 'w' ? 'b' : 'w'; }
+
+} // namespace CheckersUI
+
+#endif // CHECKERS_UI_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,6 @@
 #include "board_driver.h"
+#include "checkers_bot_game.h"
+#include "checkers_game.h"
 #include "chess_bot.h"
 #include "chess_engine.h"
 #include "chess_lichess.h"
@@ -15,8 +17,13 @@
 #include "sensor_test.h"
 #include "version.h"
 #include "wifi_manager_esp32.h"
+#include <Arduino.h>
 #include <LittleFS.h>
 #include <time.h>
+
+// Give the AI search (Stockchicken's recursive alpha-beta) extra stack
+// headroom beyond the 8KB default loop task stack.
+SET_LOOP_TASK_STACK_SIZE(16384);
 
 // ---------------------------
 // Game State and Configuration
@@ -28,11 +35,14 @@ enum GameMode {
   MODE_BOT = 2,
   MODE_LICHESS = 3,
   MODE_SENSOR_TEST = 4,
-  MODE_CHESS_CONNECT = 5
+  MODE_CHESS_CONNECT = 5,
+  MODE_CHECKERS = 6,
+  MODE_STOCKCHICKEN = 7
 };
 
 BotConfig botConfig = {StockfishSettings::medium(), true};
 LichessConfig lichessConfig = {""};
+StockchickenConfig stockchickenConfig = StockchickenConfig::medium();
 
 BoardDriver boardDriver;
 ChessEngine chessEngine;
@@ -45,6 +55,8 @@ ChessLichess* chessLichess = nullptr;
 ChessConnect* chessConnect = nullptr;
 #endif
 SensorTest* sensorTest = nullptr;
+CheckersGame* checkersGame = nullptr;
+CheckersBotGame* checkersBotGame = nullptr;
 
 GameMode currentMode = MODE_SELECTION;
 bool modeInitialized = false;
@@ -54,6 +66,7 @@ bool resetGameSelection = true;
 void showGameSelection();
 void handleGameSelection();
 void handleBotConfigSelection();
+void handleStockchickenConfigSelection();
 void initializeSelectedMode(GameMode mode);
 bool resumeLiveGameFromFlash(bool requireBoardMatch);
 
@@ -277,6 +290,22 @@ void loop() {
           sensorTest->update();
       }
       break;
+    case MODE_CHECKERS:
+      if (checkersGame != nullptr) {
+        if (checkersGame->isGameOver())
+          showGameSelection();
+        else
+          checkersGame->update();
+      }
+      break;
+    case MODE_STOCKCHICKEN:
+      if (checkersBotGame != nullptr) {
+        if (checkersBotGame->isGameOver())
+          showGameSelection();
+        else
+          checkersBotGame->update();
+      }
+      break;
 #ifdef CHESSCONNECT_ENABLED
     case MODE_CHESS_CONNECT:
       if (chessConnect != nullptr) {
@@ -310,21 +339,28 @@ void showGameSelection() {
   boardDriver.setSquareLED(4, 3, LedColors::Yellow);
   // Position 4: Sensor Test (row 4, col 4) - Red
   boardDriver.setSquareLED(4, 4, LedColors::Red);
+  // Position 5: Checkers (row 2, col 3) - Purple
+  boardDriver.setSquareLED(3, 7, LedColors::Purple);
+  // Position 6: Checkers vs Stockchicken (row 2, col 4) - Cyan
+  boardDriver.setSquareLED(4, 7, LedColors::Cyan);
   boardDriver.showLEDs();
   boardDriver.releaseLEDs();
   webLog.println("=============== Game Selection Mode ===============");
-  webLog.println("Four LEDs are lit in the center of the board:");
+  webLog.println("Six LEDs are lit in the center of the board:");
   webLog.println("  Blue:   Chess Moves (Human vs Human)");
   webLog.println("  Green:  Chess Bot (Human vs AI)");
   webLog.println("  Yellow: Lichess (Play online games)");
   webLog.println("  Red:    Sensor Test");
-  webLog.println("Place any chess piece on a LED to select that mode");
+  webLog.println("  Purple: Checkers (Human vs Human)");
+  webLog.println("  Cyan:   Checkers vs Stockchicken (Human vs AI)");
+  webLog.println("Place any piece on a LED to select that mode");
   webLog.println("===================================================");
 }
 
 void handleGameSelection() {
   boardDriver.readSensors();
-  bool currState[4] = {boardDriver.getSensorState(3, 3), boardDriver.getSensorState(3, 4), boardDriver.getSensorState(4, 3), boardDriver.getSensorState(4, 4)};
+  const int SELECTOR_COUNT = 6;
+  bool currState[SELECTOR_COUNT] = {boardDriver.getSensorState(3, 3), boardDriver.getSensorState(3, 4), boardDriver.getSensorState(4, 3), boardDriver.getSensorState(4, 4), boardDriver.getSensorState(3, 7), boardDriver.getSensorState(4, 7)};
 
   struct SelectorState {
     int emptyCount;
@@ -332,17 +368,17 @@ void handleGameSelection() {
     bool readyForSelection;
   };
   const int DEBOUNCE_CYCLES = (DEBOUNCE_MS / SENSOR_READ_DELAY_MS) + 2;
-  static SelectorState selectorStates[4] = {};
+  static SelectorState selectorStates[SELECTOR_COUNT] = {};
 
   if (resetGameSelection) {
-    for (int i = 0; i < 4; ++i) {
+    for (int i = 0; i < SELECTOR_COUNT; ++i) {
       selectorStates[i].emptyCount = 0;
       selectorStates[i].occupiedCount = 0;
       selectorStates[i].readyForSelection = false;
     }
     resetGameSelection = false;
   }
-  for (int i = 0; i < 4; ++i) {
+  for (int i = 0; i < SELECTOR_COUNT; ++i) {
     if (!currState[i]) {
       if (selectorStates[i].emptyCount < DEBOUNCE_CYCLES)
         selectorStates[i].emptyCount++;
@@ -361,7 +397,7 @@ void handleGameSelection() {
   }
 
   // Check for valid rising edge (empty for DEBOUNCE_CYCLES, then occupied for DEBOUNCE_CYCLES)
-  for (int i = 0; i < 4; ++i) {
+  for (int i = 0; i < SELECTOR_COUNT; ++i) {
     if (selectorStates[i].readyForSelection && selectorStates[i].occupiedCount >= DEBOUNCE_CYCLES) {
       switch (i) {
         case 0:
@@ -389,6 +425,19 @@ void handleGameSelection() {
           currentMode = MODE_SENSOR_TEST;
           modeInitialized = false;
           boardDriver.clearAllLEDs();
+          break;
+        case 4:
+          webLog.println("Mode: 'Checkers' Selected!");
+          currentMode = MODE_CHECKERS;
+          modeInitialized = false;
+          boardDriver.clearAllLEDs();
+          break;
+        case 5:
+          webLog.println("Mode: 'Checkers vs Stockchicken' Selected! Showing difficulty selection...");
+          currentMode = MODE_STOCKCHICKEN;
+          modeInitialized = false;
+          boardDriver.clearAllLEDs();
+          handleStockchickenConfigSelection();
           break;
       }
       break;
@@ -432,6 +481,20 @@ void initializeSelectedMode(GameMode mode) {
         delete sensorTest;
       sensorTest = new SensorTest(&boardDriver);
       sensorTest->begin();
+      break;
+    case MODE_CHECKERS:
+      webLog.println("Starting 'Checkers'...");
+      if (checkersGame != nullptr)
+        delete checkersGame;
+      checkersGame = new CheckersGame(&boardDriver);
+      checkersGame->begin();
+      break;
+    case MODE_STOCKCHICKEN:
+      webLog.printf("Starting 'Checkers vs Stockchicken' (Depth: %d)...\n", stockchickenConfig.depth);
+      if (checkersBotGame != nullptr)
+        delete checkersBotGame;
+      checkersBotGame = new CheckersBotGame(&boardDriver, stockchickenConfig);
+      checkersBotGame->begin();
       break;
 #ifdef CHESSCONNECT_ENABLED
     case MODE_CHESS_CONNECT:
@@ -516,6 +579,54 @@ void handleBotConfigSelection() {
         }
         prevState[rowIdx][col] = curr;
       }
+    }
+
+    firstLoop = false;
+    delay(SENSOR_READ_DELAY_MS);
+  }
+}
+
+void handleStockchickenConfigSelection() {
+  int row = 4;
+  webLog.println("====== Stockchicken Difficulty Selection ======");
+  webLog.println("You play White. Select Stockchicken's search depth:");
+  webLog.println("- File B: Easy (depth 2)");
+  webLog.println("- File D: Medium (depth 4)");
+  webLog.println("- File F: Hard (depth 6)");
+
+  boardDriver.acquireLEDs();
+  boardDriver.setSquareLED(row, 1, LedColors::Green);
+  boardDriver.setSquareLED(row, 3, LedColors::Yellow);
+  boardDriver.setSquareLED(row, 5, LedColors::Red);
+  boardDriver.showLEDs();
+  boardDriver.releaseLEDs();
+
+  webLog.println("Waiting for difficulty selection...");
+
+  static bool prevState[8] = {};
+  bool firstLoop = true;
+
+  while (true) {
+    boardDriver.readSensors();
+
+    for (int col : {1, 3, 5}) {
+      bool curr = boardDriver.getSensorState(row, col);
+      // Only accept selection if square was previously empty and is now occupied
+      if (!firstLoop && !prevState[col] && curr) {
+        if (col == 1) {
+          stockchickenConfig = StockchickenConfig::easy();
+          webLog.println("Configuration: Stockchicken Easy (depth 2)");
+        } else if (col == 3) {
+          stockchickenConfig = StockchickenConfig::medium();
+          webLog.println("Configuration: Stockchicken Medium (depth 4)");
+        } else {
+          stockchickenConfig = StockchickenConfig::hard();
+          webLog.println("Configuration: Stockchicken Hard (depth 6)");
+        }
+        boardDriver.clearAllLEDs();
+        return;
+      }
+      prevState[col] = curr;
     }
 
     firstLoop = false;

--- a/src/stockchicken.cpp
+++ b/src/stockchicken.cpp
@@ -1,0 +1,222 @@
+#include "stockchicken.h"
+#include <string.h>
+
+namespace {
+constexpr int MAN_VALUE = 100;
+constexpr int KING_VALUE = 130;
+constexpr int INF = 1000000;
+constexpr int WIN_SCORE = 100000;
+} // namespace
+
+Stockchicken::Stockchicken(const StockchickenConfig& config) : depth(config.depth) {}
+
+void Stockchicken::applyMove(char board[8][8], int fromRow, int fromCol, const CheckersEngine::Move& move, char& piece) const {
+  piece = board[fromRow][fromCol];
+  board[fromRow][fromCol] = ' ';
+  if (move.isCapture)
+    board[move.capturedRow][move.capturedCol] = ' ';
+  if (engine.isPromotion(piece, move.toRow))
+    piece = (CheckersEngine::getPieceColor(piece) == 'w') ? 'W' : 'B';
+  board[move.toRow][move.toCol] = piece;
+}
+
+int Stockchicken::evaluate(const char board[8][8], char color) {
+  int score = 0;
+  for (int r = 0; r < 8; r++) {
+    for (int c = 0; c < 8; c++) {
+      char piece = board[r][c];
+      if (piece == ' ')
+        continue;
+
+      int value;
+      if (CheckersEngine::isKing(piece)) {
+        value = KING_VALUE;
+      } else {
+        char pieceColor = CheckersEngine::getPieceColor(piece);
+        int advancement = (pieceColor == 'w') ? (7 - r) : r; // 0..7, higher = closer to promotion
+        value = MAN_VALUE + advancement;
+      }
+
+      score += (CheckersEngine::getPieceColor(piece) == color) ? value : -value;
+    }
+  }
+  return score;
+}
+
+int Stockchicken::bestTurnScore(char board[8][8], char color, int plies, int alpha, int beta) const {
+  if (plies <= 0)
+    return evaluate(board, color);
+
+  bool any = false;
+  int best = -INF;
+  bool mustCapture = engine.hasAnyCapture(board, color);
+
+  for (int r = 0; r < 8; r++) {
+    for (int c = 0; c < 8; c++) {
+      if (CheckersEngine::getPieceColor(board[r][c]) != color)
+        continue;
+
+      CheckersEngine::Move moves[CheckersEngine::MAX_MOVES];
+      int moveCount;
+      engine.getLegalMoves(board, r, c, color, mustCapture, moves, moveCount);
+
+      for (int i = 0; i < moveCount; i++) {
+        any = true;
+        char child[8][8];
+        memcpy(child, board, sizeof(child));
+        char piece;
+        applyMove(child, r, c, moves[i], piece);
+
+        int score;
+        if (moves[i].isCapture && !engine.isPromotion(board[r][c], moves[i].toRow)) {
+          CheckersEngine::Move cont[CheckersEngine::MAX_MOVES];
+          int contCount;
+          engine.getContinuationCaptures(child, moves[i].toRow, moves[i].toCol, color, cont, contCount);
+          if (contCount > 0)
+            score = continueTurnScore(child, color, moves[i].toRow, moves[i].toCol, plies, alpha, beta, MAX_TURN_STEPS - 1);
+          else
+            score = -bestTurnScore(child, opposite(color), plies - 1, -beta, -alpha);
+        } else {
+          score = -bestTurnScore(child, opposite(color), plies - 1, -beta, -alpha);
+        }
+
+        if (score > best)
+          best = score;
+        if (best > alpha)
+          alpha = best;
+        if (alpha >= beta)
+          return best;
+      }
+    }
+  }
+
+  if (!any)
+    return -WIN_SCORE; // `color` has no legal move - a loss
+
+  return best;
+}
+
+int Stockchicken::continueTurnScore(char board[8][8], char color, int row, int col, int plies, int alpha, int beta, int chainsLeft) const {
+  CheckersEngine::Move moves[CheckersEngine::MAX_MOVES];
+  int moveCount;
+  engine.getContinuationCaptures(board, row, col, color, moves, moveCount);
+
+  int best = -INF;
+  for (int i = 0; i < moveCount; i++) {
+    char child[8][8];
+    memcpy(child, board, sizeof(child));
+    char piece;
+    applyMove(child, row, col, moves[i], piece);
+
+    int score;
+    if (engine.isPromotion(board[row][col], moves[i].toRow)) {
+      score = -bestTurnScore(child, opposite(color), plies - 1, -beta, -alpha);
+    } else {
+      CheckersEngine::Move cont[CheckersEngine::MAX_MOVES];
+      int contCount;
+      engine.getContinuationCaptures(child, moves[i].toRow, moves[i].toCol, color, cont, contCount);
+      if (contCount > 0 && chainsLeft > 0)
+        score = continueTurnScore(child, color, moves[i].toRow, moves[i].toCol, plies, alpha, beta, chainsLeft - 1);
+      else
+        score = -bestTurnScore(child, opposite(color), plies - 1, -beta, -alpha);
+    }
+
+    if (score > best)
+      best = score;
+    if (best > alpha)
+      alpha = best;
+    if (alpha >= beta)
+      break;
+  }
+  return best;
+}
+
+int Stockchicken::exploreStep(char board[8][8], char color, int row, int col, char pieceBeforeMove, const CheckersEngine::Move moves[CheckersEngine::MAX_MOVES], int moveCount, Turn& turn, int stepIndex, int plies, int alpha, int beta, int chainsLeft) const {
+  int best = -INF;
+  Step bestStep = {row, col, moves[0]};
+  Turn bestContinuation;
+  bestContinuation.stepCount = 0;
+
+  for (int i = 0; i < moveCount; i++) {
+    char child[8][8];
+    memcpy(child, board, sizeof(child));
+    char piece;
+    applyMove(child, row, col, moves[i], piece);
+
+    Turn continuation;
+    continuation.stepCount = 0;
+    int score;
+
+    if (moves[i].isCapture && !engine.isPromotion(pieceBeforeMove, moves[i].toRow) && chainsLeft > 0) {
+      CheckersEngine::Move cont[CheckersEngine::MAX_MOVES];
+      int contCount;
+      engine.getContinuationCaptures(child, moves[i].toRow, moves[i].toCol, color, cont, contCount);
+      if (contCount > 0)
+        score = exploreStep(child, color, moves[i].toRow, moves[i].toCol, piece, cont, contCount, continuation, 0, plies, alpha, beta, chainsLeft - 1);
+      else
+        score = -bestTurnScore(child, opposite(color), plies - 1, -beta, -alpha);
+    } else {
+      score = -bestTurnScore(child, opposite(color), plies - 1, -beta, -alpha);
+    }
+
+    if (score > best) {
+      best = score;
+      bestStep = {row, col, moves[i]};
+      bestContinuation = continuation;
+    }
+    if (best > alpha)
+      alpha = best;
+    if (alpha >= beta)
+      break;
+  }
+
+  turn.steps[stepIndex] = bestStep;
+  turn.stepCount = stepIndex + 1;
+  for (int i = 0; i < bestContinuation.stepCount; i++)
+    turn.steps[stepIndex + 1 + i] = bestContinuation.steps[i];
+  turn.stepCount += bestContinuation.stepCount;
+
+  return best;
+}
+
+bool Stockchicken::chooseTurn(const char board[8][8], char color, Turn& turn) const {
+  char rootBoard[8][8];
+  memcpy(rootBoard, board, sizeof(rootBoard));
+
+  int alpha = -INF;
+  int beta = INF;
+  int best = alpha;
+  bool found = false;
+  Turn bestTurn;
+  bestTurn.stepCount = 0;
+  bool mustCapture = engine.hasAnyCapture(rootBoard, color);
+
+  for (int r = 0; r < 8; r++) {
+    for (int c = 0; c < 8; c++) {
+      if (CheckersEngine::getPieceColor(rootBoard[r][c]) != color)
+        continue;
+
+      CheckersEngine::Move moves[CheckersEngine::MAX_MOVES];
+      int moveCount;
+      engine.getLegalMoves(rootBoard, r, c, color, mustCapture, moves, moveCount);
+      if (moveCount == 0)
+        continue;
+
+      Turn candidate;
+      candidate.stepCount = 0;
+      int score = exploreStep(rootBoard, color, r, c, rootBoard[r][c], moves, moveCount, candidate, 0, depth, alpha, beta, MAX_TURN_STEPS - 1);
+
+      if (!found || score > best) {
+        best = score;
+        bestTurn = candidate;
+        found = true;
+      }
+      if (best > alpha)
+        alpha = best;
+    }
+  }
+
+  if (found)
+    turn = bestTurn;
+  return found;
+}

--- a/src/stockchicken.h
+++ b/src/stockchicken.h
@@ -1,0 +1,75 @@
+#ifndef STOCKCHICKEN_H
+#define STOCKCHICKEN_H
+
+#include "checkers_engine.h"
+
+// ---------------------------
+// Stockchicken: checkers AI opponent
+// ---------------------------
+// A small alpha-beta search built on top of CheckersEngine's move
+// generation. Pure C++, no Arduino dependencies - same as CheckersEngine.
+//
+// "Depth" is the number of full turns (one side's complete move, including
+// any forced multi-jump continuation) to look ahead. Each side's turn
+// counts as one ply, regardless of how many individual jumps it contains.
+struct StockchickenConfig {
+  int depth;
+
+  static StockchickenConfig easy() { return {2}; }
+  static StockchickenConfig medium() { return {4}; }
+  static StockchickenConfig hard() { return {6}; }
+};
+
+class Stockchicken {
+ public:
+  explicit Stockchicken(const StockchickenConfig& config);
+
+  // One step (pick up fromRow/fromCol, place per `move`) within a turn. A
+  // turn has more than one step only when the same piece is forced into
+  // consecutive captures.
+  struct Step {
+    int fromRow, fromCol;
+    CheckersEngine::Move move;
+  };
+
+  // Generous bound on consecutive captures by a single piece in one turn.
+  static constexpr int MAX_TURN_STEPS = 6;
+
+  struct Turn {
+    Step steps[MAX_TURN_STEPS];
+    int stepCount;
+  };
+
+  // Picks the best full turn for `color` on `board`. Returns false if
+  // `color` has no legal move (game over).
+  bool chooseTurn(const char board[8][8], char color, Turn& turn) const;
+
+ private:
+  CheckersEngine engine;
+  int depth;
+
+  // Pure scoring (no move recording), from `color`'s perspective, with
+  // `plies` whole turns left to search including this one.
+  int bestTurnScore(char board[8][8], char color, int plies, int alpha, int beta) const;
+
+  // Continues a forced multi-jump for the piece at (row, col) and returns
+  // the resulting score from `color`'s perspective. `chainsLeft` bounds how
+  // many further jumps in this turn will be explored.
+  int continueTurnScore(char board[8][8], char color, int row, int col, int plies, int alpha, int beta, int chainsLeft) const;
+
+  // Like bestTurnScore's root iteration, but records the chosen move (and
+  // any forced continuation) into `turn` starting at `stepIndex`. Returns
+  // the score from `color`'s perspective.
+  int exploreStep(char board[8][8], char color, int row, int col, char pieceBeforeMove, const CheckersEngine::Move moves[CheckersEngine::MAX_MOVES], int moveCount, Turn& turn, int stepIndex, int plies, int alpha, int beta, int chainsLeft) const;
+
+  // Applies `move` (including capture removal and promotion) to `board`,
+  // reporting the resulting piece (possibly promoted) in `piece`.
+  void applyMove(char board[8][8], int fromRow, int fromCol, const CheckersEngine::Move& move, char& piece) const;
+
+  // Material + advancement score from `color`'s perspective.
+  static int evaluate(const char board[8][8], char color);
+
+  static char opposite(char color) { return color == 'w' ? 'b' : 'w'; }
+};
+
+#endif // STOCKCHICKEN_H


### PR DESCRIPTION
Adds a Checkers game mode to the board, playable either human-vs-human or human-vs-AI against a new opponent, humorously named Stockchicken.

- `checkers_engine` - standard American checkers rules (mandatory captures, multi-jump continuation, kings)
- `checkers_ui` - shared sensor/LED turn handling used by both checkers modes, including a physical "quit to menu" gesture (hold pieces on both light/unplayable corner squares), somewhat a gesture to resign and agree.
- `checkers_game` - human vs human mode
- `checkers_bot_game` + `stockchicken` - human vs AI mode; Stockchicken is an alpha-beta search with adjustable depth, selectable from the physical board the same way the existing chess bot's difficulty is chosen

If someone wants to keep the board UI clean (middle four squares) then an enable/disable function could be implemented in the web UI.