### PR TITLE
Fix bot turn desync

### DIFF
--- a/src/chess_bot.cpp
+++ b/src/chess_bot.cpp
@@ -55,9 +55,10 @@ void ChessBot::update() {
     }
   } else {
     // Bot's turn
-    makeBotMove();
-    updateGameStatus();
-    wifiManager->updateBoardState(currentFEN(), currentEvaluation);
+    if (makeBotMove()) {
+      updateGameStatus();
+      wifiManager->updateBoardState(currentFEN(), currentEvaluation);
+    }
   }
 
   boardDriver->updateSensorPrev();
@@ -125,7 +126,7 @@ bool ChessBot::parseStockfishResponse(const String& response, String& bestMove, 
   return true;
 }
 
-void ChessBot::makeBotMove() {
+bool ChessBot::makeBotMove() {
   webLog.println("=== BOT MOVE CALCULATION ===");
   std::atomic<bool>* stopAnimation = boardDriver->startThinkingAnimation();
   String bestMove;
@@ -146,17 +147,22 @@ void ChessBot::makeBotMove() {
       bool isBotPiece = (botPlaysWhite && piece >= 'A' && piece <= 'Z') || (!botPlaysWhite && piece >= 'a' && piece <= 'z');
       if (!isBotPiece) {
         webLog.printf("ERROR: Bot tried to move a %s piece, but bot plays %s. Piece at source: %c\n", (piece >= 'A' && piece <= 'Z') ? "WHITE" : "BLACK", botPlaysWhite ? "WHITE" : "BLACK", piece);
-        return;
+        delay(1000);
+        return false;
       }
       if (piece == ' ') {
         webLog.println("ERROR: Bot tried to move from an empty square!");
-        return;
+        delay(1000);
+        return false;
       }
       applyMove(fromRow, fromCol, toRow, toCol, (bestMove.length() >= 5) ? bestMove[4] : ' ', true);
-    } else {
-      webLog.println("Failed to parse Stockfish UCI move: " + bestMove);
+      return true;
     }
+    webLog.println("Failed to parse Stockfish UCI move: " + bestMove);
+    delay(1000);
+    return false;
   }
+  return false;
 }
 
 void ChessBot::waitForRemoteMoveCompletion(int fromRow, int fromCol, int toRow, int toCol, bool isCapture, bool isEnPassant, int enPassantCapturedPawnRow) {

--- a/src/chess_bot.h
+++ b/src/chess_bot.h
@@ -19,8 +19,10 @@ class ChessBot : public ChessGame {
   String makeStockfishRequest(const String& fen);
   bool parseStockfishResponse(const String& response, String& bestMove, float& evaluation);
 
-  // Game flow (Stockfish-specific)
-  void makeBotMove();
+  // Game flow (Stockfish-specific). Returns false if no move was actually
+  // applied (parse failure, desynced piece colour, etc.) so the caller
+  // doesn't advance the turn on a no-op.
+  bool makeBotMove();
 
  protected:
   float currentEvaluation; // Evaluation (in pawns, positive = White advantage)


### PR DESCRIPTION
ChessBot::makeBotMove() has three early-return paths (stockfish API parse failure,
attempt to move wrong-coloured piece and empty source square) that skip applyMove() entirely.  Subsequently no move is made and no LEDs shown, yet silently update() calls updateGameStatus(), which advances the turn unconditionally regardless of whether a move actually happened.

If Stockfish ever returns a move that doesn't parse or doesn't match the current board (e.g. after a transient API hiccup), the turn would flip while the physical board stayed untouched, permanently desyncing the game state from the board until manually fixed via FEN edit.

makeBotMove() now returns false on every no-op path (with a short backoff so repeated failures don't hammer the API), and update() only advances the turn when a move was actually applied - the bot's turn simply retries on the next loop pass instead.